### PR TITLE
Switch to GATs and allow also immutable borrows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "interior_mut"
 version = "0.1.0"
 authors = ["Kjetil Kjeka <kjetilkjeka@gmail.com>"]
+edition = "2021"
 
 license = "Apache-2.0/MIT"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,3 +97,30 @@ impl<T: ?Sized> InteriorMut<T> for std::sync::RwLock<T> {
         self.write()
     }
 }
+
+#[cfg(feature = "std")]
+impl<T: ?Sized, I: InteriorMut<T> + ?Sized> InteriorMut<T> for std::rc::Rc<I> {
+    type Ref<'a> = I::Ref<'a>
+    where
+        Self: 'a, I: 'a;
+
+    type RefMut<'a>=I::RefMut<'a>
+    where
+        Self: 'a, I: 'a;
+
+    type Error<'a>=I::Error<'a>
+    where
+        Self: 'a, I: 'a;
+
+    type ErrorMut<'a>=I::ErrorMut<'a>
+    where
+        Self: 'a, I: 'a;
+
+    fn borrow_int(&self) -> Result<Self::Ref<'_>, Self::Error<'_>> {
+        self.deref().borrow_int()
+    }
+
+    fn borrow_int_mut(&self) -> Result<Self::RefMut<'_>, Self::ErrorMut<'_>> {
+        self.deref().borrow_int_mut()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use lib::cell::RefCell;
 use lib::ops::{Deref, DerefMut};
 
 /// A trait for obtaining an immutable or mutable reference on types that allow interior mutability.
-pub trait InteriorMut<T> {
+pub trait InteriorMut<T: ?Sized> {
     /// The immutable reference type.
     type Ref<'a>: Deref<Target = T>
     where
@@ -41,7 +41,7 @@ pub trait InteriorMut<T> {
     fn borrow_int_mut(&self) -> Result<Self::RefMut<'_>, Self::ErrorMut<'_>>;
 }
 
-impl<T> InteriorMut<T> for RefCell<T> {
+impl<T: ?Sized> InteriorMut<T> for RefCell<T> {
     type Ref<'a> = lib::cell::Ref<'a, T> where T: 'a;
     type RefMut<'a> = lib::cell::RefMut<'a, T> where T: 'a;
     type Error<'a> = lib::cell::BorrowError where T: 'a;
@@ -57,7 +57,7 @@ impl<T> InteriorMut<T> for RefCell<T> {
 }
 
 #[cfg(feature = "std")]
-impl<T> InteriorMut<T> for std::sync::Mutex<T> {
+impl<T: ?Sized> InteriorMut<T> for std::sync::Mutex<T> {
     type Ref<'a> = std::sync::MutexGuard<'a, T> where T: 'a;
     type RefMut<'a> = std::sync::MutexGuard<'a, T> where T: 'a;
     type Error<'a> = std::sync::PoisonError<std::sync::MutexGuard<'a, T>> where T: 'a;
@@ -73,7 +73,7 @@ impl<T> InteriorMut<T> for std::sync::Mutex<T> {
 }
 
 #[cfg(feature = "std")]
-impl<T> InteriorMut<T> for std::sync::RwLock<T> {
+impl<T: ?Sized> InteriorMut<T> for std::sync::RwLock<T> {
     type Ref<'a> = std::sync::RwLockReadGuard<'a, T> where T: 'a;
     type RefMut<'a> = std::sync::RwLockWriteGuard<'a, T> where T: 'a;
     type Error<'a> = std::sync::PoisonError<std::sync::RwLockReadGuard<'a, T>> where T: 'a;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,12 +25,22 @@ pub trait InteriorMut<T: ?Sized> {
         Self: 'a;
 
     /// The error type for immutable borrows.
-    type Error<'a>
+    #[cfg(not(feature = "std"))]
+    type Error<'a>: core::fmt::Debug + core::fmt::Display
+    where
+        Self: 'a;
+    #[cfg(feature = "std")]
+    type Error<'a>: std::error::Error
     where
         Self: 'a;
 
     /// The error type for mutable borrows.
-    type ErrorMut<'a>
+    #[cfg(not(feature = "std"))]
+    type ErrorMut<'a>: core::fmt::Debug + core::fmt::Display
+    where
+        Self: 'a;
+    #[cfg(feature = "std")]
+    type ErrorMut<'a>: std::error::Error
     where
         Self: 'a;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,55 +1,89 @@
 //! A crate for abstracting over interior mutable containers.
 
-#![cfg_attr(not(feature="std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 mod lib {
-    #[cfg(feature="std")]
-    pub use std::*;
-    #[cfg(not(feature="std"))]
+    #[cfg(not(feature = "std"))]
     pub use core::*;
+    #[cfg(feature = "std")]
+    pub use std::*;
 }
 
-use lib::ops::DerefMut;
 use lib::cell::RefCell;
+use lib::ops::{Deref, DerefMut};
 
-/// A trait for obtaining a mutable reference on types that allow interior mutability.
-pub trait InteriorMut<'a, T> {
+/// A trait for obtaining an immutable or mutable reference on types that allow interior mutability.
+pub trait InteriorMut<T> {
+    /// The immutable reference type.
+    type Ref<'a>: Deref<Target = T>
+    where
+        Self: 'a;
 
-    /// The reference type
-    type RefMut: DerefMut<Target=T> + 'a;
+    /// The mutable reference type.
+    type RefMut<'a>: DerefMut<Target = T>
+    where
+        Self: 'a;
 
-    /// The error type
-    type Error;
+    /// The error type for immutable borrows.
+    type Error<'a>
+    where
+        Self: 'a;
+
+    /// The error type for mutable borrows.
+    type ErrorMut<'a>
+    where
+        Self: 'a;
+
+    /// Immutably borrows the internal value from an immutable reference.
+    fn borrow_int(&self) -> Result<Self::Ref<'_>, Self::Error<'_>>;
 
     /// Mutably borrows the internal value from an immutable reference.
-    fn borrow_int_mut(&'a self) -> Result<Self::RefMut, Self::Error>;
+    fn borrow_int_mut(&self) -> Result<Self::RefMut<'_>, Self::ErrorMut<'_>>;
 }
 
-impl<'a, T: 'a> InteriorMut<'a, T> for RefCell<T> {
-    type RefMut = lib::cell::RefMut<'a, T>;
-    type Error = lib::cell::BorrowMutError;
+impl<T> InteriorMut<T> for RefCell<T> {
+    type Ref<'a> = lib::cell::Ref<'a, T> where T: 'a;
+    type RefMut<'a> = lib::cell::RefMut<'a, T> where T: 'a;
+    type Error<'a> = lib::cell::BorrowError where T: 'a;
+    type ErrorMut<'a> = lib::cell::BorrowMutError where T: 'a;
 
-    fn borrow_int_mut(&'a self) -> Result<Self::RefMut, Self::Error> {
+    fn borrow_int(&self) -> Result<Self::Ref<'_>, Self::Error<'_>> {
+        RefCell::try_borrow(self)
+    }
+
+    fn borrow_int_mut(&self) -> Result<Self::RefMut<'_>, Self::ErrorMut<'_>> {
         RefCell::try_borrow_mut(self)
     }
 }
 
-#[cfg(feature="std")]
-impl<'a, T: 'a> InteriorMut<'a, T> for std::sync::Mutex<T> {
-    type RefMut = std::sync::MutexGuard<'a, T>;
-    type Error = std::sync::PoisonError<std::sync::MutexGuard<'a, T>>;
+#[cfg(feature = "std")]
+impl<T> InteriorMut<T> for std::sync::Mutex<T> {
+    type Ref<'a> = std::sync::MutexGuard<'a, T> where T: 'a;
+    type RefMut<'a> = std::sync::MutexGuard<'a, T> where T: 'a;
+    type Error<'a> = std::sync::PoisonError<std::sync::MutexGuard<'a, T>> where T: 'a;
+    type ErrorMut<'a> = std::sync::PoisonError<std::sync::MutexGuard<'a, T>> where T: 'a;
 
-    fn borrow_int_mut(&'a self) -> std::sync::LockResult<std::sync::MutexGuard<'a, T>> {
+    fn borrow_int(&self) -> Result<Self::Ref<'_>, Self::Error<'_>> {
+        self.lock()
+    }
+
+    fn borrow_int_mut(&self) -> Result<Self::RefMut<'_>, Self::ErrorMut<'_>> {
         self.lock()
     }
 }
 
-#[cfg(feature="std")]
-impl<'a, T: 'a> InteriorMut<'a, T> for std::sync::RwLock<T> {
-    type RefMut = std::sync::RwLockWriteGuard<'a, T>;
-    type Error = std::sync::PoisonError<std::sync::RwLockWriteGuard<'a, T>>;
+#[cfg(feature = "std")]
+impl<T> InteriorMut<T> for std::sync::RwLock<T> {
+    type Ref<'a> = std::sync::RwLockReadGuard<'a, T> where T: 'a;
+    type RefMut<'a> = std::sync::RwLockWriteGuard<'a, T> where T: 'a;
+    type Error<'a> = std::sync::PoisonError<std::sync::RwLockReadGuard<'a, T>> where T: 'a;
+    type ErrorMut<'a> = std::sync::PoisonError<std::sync::RwLockWriteGuard<'a, T>> where T: 'a;
 
-    fn borrow_int_mut(&'a self) -> std::sync::LockResult<std::sync::RwLockWriteGuard<'a, T>> {
+    fn borrow_int(&self) -> Result<Self::Ref<'_>, Self::Error<'_>> {
+        self.read()
+    }
+
+    fn borrow_int_mut(&self) -> Result<Self::RefMut<'_>, Self::ErrorMut<'_>> {
         self.write()
     }
 }


### PR DESCRIPTION
GATs make it more convenient because of less lifetime noise.

Immutable borrows are sometimes special as well, such as for the `RwLock`, which does not support read-locking via `Borrow`.

Unsized types are also allowed in `RefCell`, `Mutex` and `RwLock`.

Error types should be bounded by `Error` in std. I added the closest equivalent from `core` for no-std.